### PR TITLE
RF: Use optional_package to allow code to assume pyzstd is present

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -95,7 +95,6 @@ from .spatialimages import (HeaderDataError, HeaderTypeError,
 from .fileholders import copy_file_map
 from .batteryrunners import Report
 from .arrayproxy import ArrayProxy
-from .openers import HAVE_ZSTD
 
 # Sub-parts of standard analyze header from
 # Mayo dbh.h file
@@ -907,9 +906,7 @@ class AnalyzeImage(SpatialImage):
     _meta_sniff_len = header_class.sizeof_hdr
     files_types = (('image', '.img'), ('header', '.hdr'))
     valid_exts = ('.img', '.hdr')
-    _compressed_suffixes = ('.gz', '.bz2')
-    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    _compressed_suffixes = ('.gz', '.bz2', '.zst')
 
     makeable = True
     rw = True

--- a/nibabel/benchmarks/bench_fileslice.py
+++ b/nibabel/benchmarks/bench_fileslice.py
@@ -14,10 +14,11 @@ from timeit import timeit
 import numpy as np
 
 from io import BytesIO
-from ..openers import ImageOpener, HAVE_ZSTD
+from ..openers import ImageOpener
 from ..fileslice import fileslice
 from ..rstutils import rst_table
 from ..tmpdirs import InTemporaryDirectory
+from ..optpkg import optional_package
 
 SHAPE = (64, 64, 32, 100)
 ROW_NAMES = [f'axis {i}, len {dim}' for i, dim in enumerate(SHAPE)]
@@ -25,6 +26,7 @@ COL_NAMES = ['mid int',
              'step 1',
              'half step 1',
              'step mid int']
+HAVE_ZSTD = optional_package("pyzstd")[1]
 
 
 def _slices_for_len(L):
@@ -104,11 +106,10 @@ def bench_fileslice(bytes=True,
         my_table('bz2 slice - raw (ratio)',
                  np.dstack((bz2_times, bz2_times / bz2_base)),
                  bz2_base)
-    if HAVE_ZSTD:
-        if zst:
-            with InTemporaryDirectory():
-                zst_times, zst_base = run_slices('data.zst', repeat)
-            my_table('zst slice - raw (ratio)',
-                     np.dstack((zst_times, zst_times / zst_base)),
-                     zst_base)
+    if zst and HAVE_ZSTD:
+        with InTemporaryDirectory():
+            zst_times, zst_base = run_slices('data.zst', repeat)
+        my_table('zst slice - raw (ratio)',
+                 np.dstack((zst_times, zst_times / zst_base)),
+                 zst_base)
     sys.stdout.flush()

--- a/nibabel/brikhead.py
+++ b/nibabel/brikhead.py
@@ -43,7 +43,6 @@ from .spatialimages import (
     ImageDataError
 )
 from .volumeutils import Recoder
-from .openers import HAVE_ZSTD
 
 # used for doc-tests
 filepath = os.path.dirname(os.path.realpath(__file__))
@@ -491,9 +490,7 @@ class AFNIImage(SpatialImage):
     header_class = AFNIHeader
     valid_exts = ('.brik', '.head')
     files_types = (('image', '.brik'), ('header', '.head'))
-    _compressed_suffixes = ('.gz', '.bz2', '.Z')
-    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    _compressed_suffixes = ('.gz', '.bz2', '.Z', '.zst')
     makeable = False
     rw = False
     ImageArrayProxy = AFNIArrayProxy

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -13,15 +13,13 @@ import os
 import numpy as np
 
 from .filename_parser import splitext_addext, _stringify_path
-from .openers import ImageOpener, HAVE_ZSTD
+from .openers import ImageOpener
 from .filebasedimages import ImageFileError
 from .imageclasses import all_image_classes
 from .arrayproxy import is_proxy
 from .deprecated import deprecate_with_version
 
-_compressed_suffixes = ('.gz', '.bz2')
-if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-    _compressed_suffixes = (*_compressed_suffixes, '.zst')
+_compressed_suffixes = ('.gz', '.bz2', '.zst')
 
 
 def load(filename, **kwargs):

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -16,7 +16,6 @@ from .externals.netcdf import netcdf_file
 
 from .spatialimages import SpatialHeader, SpatialImage
 from .fileslice import canonical_slicers
-from .openers import HAVE_ZSTD
 
 _dt_dict = {
     ('b', 'unsigned'): np.uint8,
@@ -317,9 +316,7 @@ class Minc1Image(SpatialImage):
     _meta_sniff_len = 4
     valid_exts = ('.mnc',)
     files_types = (('image', '.mnc'),)
-    _compressed_suffixes = ('.gz', '.bz2')
-    if HAVE_ZSTD:  # If pyzstd installed., add .zst suffix
-        _compressed_suffixes = (*_compressed_suffixes, '.zst')
+    _compressed_suffixes = ('.gz', '.bz2', '.zst')
 
     makeable = True
     rw = False

--- a/nibabel/tests/test_analyze.py
+++ b/nibabel/tests/test_analyze.py
@@ -30,7 +30,7 @@ from .. import imageglobals
 from ..casting import as_int
 from ..tmpdirs import InTemporaryDirectory
 from ..arraywriters import WriterError
-from ..openers import HAVE_ZSTD
+from ..optpkg import optional_package
 
 import pytest
 from numpy.testing import (assert_array_equal, assert_array_almost_equal)
@@ -40,6 +40,8 @@ from ..testing import (data_path, suppress_warnings, assert_dt_equal,
 
 from .test_wrapstruct import _TestLabeledWrapStruct
 from . import test_spatialimages as tsi
+
+HAVE_ZSTD = optional_package("pyzstd")[1]
 
 header_file = os.path.join(data_path, 'analyze.hdr')
 

--- a/nibabel/tests/test_minc1.py
+++ b/nibabel/tests/test_minc1.py
@@ -22,7 +22,7 @@ from ..externals.netcdf import netcdf_file
 from ..deprecated import ModuleProxy
 from .. import minc1
 from ..minc1 import Minc1File, Minc1Image, MincHeader
-from ..openers import HAVE_ZSTD
+from ..optpkg import optional_package
 
 from ..tmpdirs import InTemporaryDirectory
 from ..deprecator import ExpiredDeprecationError
@@ -33,9 +33,7 @@ import pytest
 from . import test_spatialimages as tsi
 from .test_fileslice import slicer_samples
 
-# only import ZstdFile, if installed
-if HAVE_ZSTD:
-    from ..openers import ZstdFile
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 EG_FNAME = pjoin(data_path, 'tiny.mnc')
 
@@ -178,7 +176,7 @@ class TestMinc1File(_TestMincFile):
             openers_exts = [(gzip.open, '.gz'),
                             (bz2.BZ2File, '.bz2')]
             if HAVE_ZSTD:  # add .zst to test if installed
-                openers_exts += [(ZstdFile, '.zst')]
+                openers_exts += [(pyzstd.ZstdFile, '.zst')]
             with InTemporaryDirectory():
                 for opener, ext in openers_exts:
                     fname = 'test.mnc' + ext

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -18,17 +18,17 @@ from ..openers import (Opener,
                        ImageOpener,
                        HAVE_INDEXED_GZIP,
                        BZ2File,
-                       HAVE_ZSTD)
+                       )
 from ..tmpdirs import InTemporaryDirectory
 from ..volumeutils import BinOpener
+from ..optpkg import optional_package
 
 import unittest
 from unittest import mock
 import pytest
 from ..testing import error_warnings
 
-if HAVE_ZSTD:
-    from ..openers import ZstdFile
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 
 class Lunk(object):
@@ -277,7 +277,7 @@ def test_compressed_ext_case():
                     IndexedGzipFile = GzipFile
                 assert isinstance(fobj.fobj, (GzipFile, IndexedGzipFile))
             elif lext == 'zst':
-                assert isinstance(fobj.fobj, ZstdFile)
+                assert isinstance(fobj.fobj, pyzstd.ZstdFile)
             else:
                 assert isinstance(fobj.fobj, BZ2File)
 

--- a/nibabel/tests/test_volumeutils.py
+++ b/nibabel/tests/test_volumeutils.py
@@ -45,10 +45,11 @@ from ..volumeutils import (array_from_file,
                            _write_data,
                            _ftype4scaled_finite,
                            )
-from ..openers import Opener, BZ2File, HAVE_ZSTD
+from ..openers import Opener, BZ2File
 from ..casting import (floor_log2, type_info, OK_FLOATS, shared_range)
 
 from ..deprecator import ExpiredDeprecationError
+from ..optpkg import optional_package
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)
@@ -56,9 +57,7 @@ import pytest
 
 from nibabel.testing import nullcontext, assert_dt_equal, assert_allclose_safely, suppress_warnings
 
-# only import ZstdFile, if installed
-if HAVE_ZSTD:
-    from ..openers import ZstdFile
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 #: convenience variables for numpy types
 FLOAT_TYPES = np.sctypes['float']
@@ -76,7 +75,7 @@ def test__is_compressed_fobj():
                         ('.gz', gzip.open, True),
                         ('.bz2', BZ2File, True)]
         if HAVE_ZSTD:
-            file_openers += [('.zst', ZstdFile, True)]
+            file_openers += [('.zst', pyzstd.ZstdFile, True)]
         for ext, opener, compressed in file_openers:
             fname = 'test.bin' + ext
             for mode in ('wb', 'rb'):
@@ -100,7 +99,7 @@ def test_fobj_string_assumptions():
     with InTemporaryDirectory():
         openers = [open, gzip.open, BZ2File]
         if HAVE_ZSTD:
-            openers += [ZstdFile]
+            openers += [pyzstd.ZstdFile]
         for n, opener in itertools.product(
                 (256, 1024, 2560, 25600),
                 openers):
@@ -266,7 +265,7 @@ def test_array_from_file_reread():
     with InTemporaryDirectory():
         openers = [open, gzip.open, bz2.BZ2File, BytesIO]
         if HAVE_ZSTD:
-            openers += [ZstdFile]
+            openers += [pyzstd.ZstdFile]
         for shape, opener, dtt, order in itertools.product(
                 ((64,), (64, 65), (64, 65, 66)),
                 openers,

--- a/nibabel/volumeutils.py
+++ b/nibabel/volumeutils.py
@@ -19,9 +19,12 @@ from functools import reduce
 import numpy as np
 
 from .casting import shared_range, OK_FLOATS
-from .openers import Opener, BZ2File, IndexedGzipFile, HAVE_ZSTD
+from .openers import Opener, BZ2File, IndexedGzipFile
 from .deprecated import deprecate_with_version
 from .externals.oset import OrderedSet
+from .optpkg import optional_package
+
+pyzstd, HAVE_ZSTD, _ = optional_package("pyzstd")
 
 sys_is_le = sys.byteorder == 'little'
 native_code = sys_is_le and '<' or '>'
@@ -42,8 +45,7 @@ COMPRESSED_FILE_LIKES = (gzip.GzipFile, BZ2File, IndexedGzipFile)
 
 # Enable .zst support if pyzstd installed.
 if HAVE_ZSTD:
-    from .openers import ZstdFile
-    COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, ZstdFile)
+    COMPRESSED_FILE_LIKES = (*COMPRESSED_FILE_LIKES, pyzstd.ZstdFile)
 
 
 class Recoder(object):

--- a/tools/ci/env.sh
+++ b/tools/ci/env.sh
@@ -5,7 +5,7 @@ REQUIREMENTS="-r requirements.txt"
 # Minimum versions of minimum requirements
 MIN_REQUIREMENTS="-r min-requirements.txt"
 
-DEFAULT_OPT_DEPENDS="scipy matplotlib pillow pydicom h5py indexed_gzip"
+DEFAULT_OPT_DEPENDS="scipy matplotlib pillow pydicom h5py indexed_gzip pyzstd"
 # pydicom has skipped some important pre-releases, so enable a check against master
 PYDICOM_MASTER="git+https://github.com/pydicom/pydicom.git@master"
 # Minimum versions of optional requirements


### PR DESCRIPTION
Where possible, we try to code as if optional dependencies are present. `optional_package` provides three things:

1) The requested module, or a fake module that raises an error when you try to access its namespace. If we can use only this, things are cleaner.
2) A boolean indicating whether the module could be loaded. In cases where you really need to know, you can use this.
3) A `setup_module` function that will instruct test runners to skip an entire test file if it could not be loaded. Mainly useful for things like minc2 which can't be opened at all without h5py.

So this is a PR to your PR that tries to use that approach, as well as adds `pyzstd` to the optional dependencies we test on.